### PR TITLE
Prevent exceptions when saving associated models

### DIFF
--- a/lib/rescue_from_duplicate/active_record/extension.rb
+++ b/lib/rescue_from_duplicate/active_record/extension.rb
@@ -43,7 +43,7 @@ module RescueFromDuplicate::ActiveRecord
 
     def other_exception_columns(exception)
       indexes = self.class.connection.indexes(self.class.table_name)
-      indexes.detect{ |i| exception.message.include?(i.name) }.try(:columns)
+      indexes.detect{ |i| exception.message.include?(i.name) }.try(:columns) || []
     end
 
     def rescue_with_validator(columns, validator)


### PR DESCRIPTION
The problem happens when persisting a relation to the model.
If the associated model is having a duplicate exception, the columns
against which the error occurred will not exist in the current model.

This causes problems even if the model didn't use `rescue_from_duplicate`.

Ensuring to return an empty array will let the error bubble.

@cjoudrey @byroot for review.
