### PR TITLE
Adding test to PostgreSQL database to mimic case_insensitive indexes that breaks RescueFromDuplicate.missing_unique_indexes

### DIFF
--- a/spec/support/model.rb
+++ b/spec/support/model.rb
@@ -39,6 +39,9 @@ class CreateAllTables < ActiveRecord::Migration[5.2]
     add_index name, [:relation_id, :handle], unique: true
     add_index name, :name, unique: true
     add_index name, :size, unique: true
+
+    # mimics case_sensitive: false
+    add_index name, "size, lower(name)", unique: true if name == :postgresql_models
   end
 
   def self.up


### PR DESCRIPTION
I am not 100% sure how to properly fix this test, but I opened this PR to start the discussion, happy to work on it with some guidance