### PR TITLE
Do not mutate Active Record internal data

### DIFF
--- a/lib/rescue_from_duplicate/active_record/extension.rb
+++ b/lib/rescue_from_duplicate/active_record/extension.rb
@@ -45,7 +45,7 @@ module RescueFromDuplicate::ActiveRecord
     def exception_handler(exception)
       columns = exception_columns(exception)
       return unless columns
-      columns.sort!
+      columns = columns.sort
 
       self.class._rescue_from_duplicate_handlers.detect do |handler|
         handler.rescue? && columns == handler.columns


### PR DESCRIPTION
I'm experimenting with various Active Record performance patches, and they freeze the columns lists, causing this call to fail with `FrozenError: can't modify frozen Array`.

Anyway that's for the best, mutating this data is not very copy on write friendly.