### PR TITLE
support composite primary keys

### DIFF
--- a/lib/rescue_from_duplicate/active_record/extension.rb
+++ b/lib/rescue_from_duplicate/active_record/extension.rb
@@ -77,7 +77,7 @@ module RescueFromDuplicate::ActiveRecord
     end
 
     def other_exception_columns(exception)
-      indexes = self.class.connection.indexes(self.class.table_name)
+      indexes = RescueFromDuplicate.indexes_for_class(self.class)
       indexes.detect{ |i| exception.message.include?(i.name) }.try(:columns) || []
     end
   end

--- a/spec/rescue_from_duplicate_spec.rb
+++ b/spec/rescue_from_duplicate_spec.rb
@@ -6,17 +6,13 @@ shared_examples 'database error rescuing' do
 
   subject { Rescuable.new }
 
-  before do
-    allow(Rescuable).to(receive(:connection).and_return(double(indexes: [Rescuable.index])))
-  end
-
   describe "#create_or_update when the validation fails" do
     before { allow(Base).to(receive(:exception).and_return(uniqueness_exception)) }
 
     context "when the validator is present" do
       it "adds an error to the model" do
         subject.create_or_update
-        expect(subject.errors[:name]).to eq ["has already been taken"]
+        expect(subject.errors[field]).to eq ["has already been taken"]
       end
     end
 
@@ -32,30 +28,71 @@ shared_examples 'database error rescuing' do
   describe "#create_or_update when using rescuer without validation" do
     before {
       allow(Rescuable).to(receive(:_validators).and_return({}))
-      allow(Rescuable).to(receive(:_rescue_from_duplicates).and_return([Rescuable.uniqueness_rescuer]))
+      allow(Rescuable).to(receive(:_rescue_from_duplicates).and_return([rescuer]))
       allow(Base).to(receive(:exception).and_return(uniqueness_exception))
     }
 
     it "adds an error to the model" do
       subject.create_or_update
-      expect(subject.errors[:name]).to eq ["is not unique by type and shop id"]
+      expect(subject.errors[field]).to eq [without_validation_error]
     end
   end
 end
 
 describe RescueFromDuplicate::ActiveRecord do
-  context 'mysql' do
-    let(:message) { "Duplicate entry '1-Rescuable-toto' for key 'index_rescuable_on_shop_id_and_type_and_name'" }
-    it_behaves_like 'database error rescuing'
+  context 'unique key' do
+    let(:field) { :name }
+    let(:without_validation_error) { "is not unique by type and shop id" }
+    let(:rescuer) { Rescuable.uniqueness_rescuer }
+
+    before do
+      allow(Rescuable).to(receive(:connection).and_return(double(
+        indexes: [Rescuable.index],
+        primary_keys: ["id"]
+      )))
+    end
+
+    context 'mysql' do
+      let(:message) { "Duplicate entry '1-Rescuable-toto' for key 'index_rescuable_on_shop_id_and_type_and_name'" }
+      it_behaves_like 'database error rescuing'
+    end
+
+    context 'pgsql' do
+      let(:message) { "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"index_rescuable_on_shop_id_and_type_and_name\"\nDETAIL:  Key (shop_id, type, name)=(1, Rescuable, toto) already exists.\n: INSERT INTO \"postgresql_models\" (\"shop_id\", \"type\", \"name\") VALUES ($1, $2, $3) RETURNING \"id\"" }
+      it_behaves_like 'database error rescuing'
+    end
+
+    context 'sqlite3' do
+      let(:message) { "SQLite3::ConstraintException: column shop_id, type, name is not unique: INSERT INTO \"sqlite3_models\" (\"shop_id\", \"type\", \"name\") VALUES (?, ?, ?)" }
+      it_behaves_like 'database error rescuing'
+    end
   end
 
-  context 'pgsql' do
-    let(:message) { "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"index_rescuable_on_shop_id_and_type_and_name\"\nDETAIL:  Key (shop_id, type, name)=(1, Rescuable, toto) already exists.\n: INSERT INTO \"postgresql_models\" (\"shop_id\", \"type\", \"name\") VALUES ($1, $2, $3) RETURNING \"id\"" }
-    it_behaves_like 'database error rescuing'
-  end
+  context 'composite primary key' do
+    let(:field) { :key }
+    let(:without_validation_error) { "key must be unique within namespace" }
+    let(:rescuer) { Rescuable.cpk_uniqueness_rescuer }
 
-  context 'sqlite3' do
-    let(:message) { "SQLite3::ConstraintException: column shop_id, type, name is not unique: INSERT INTO \"sqlite3_models\" (\"shop_id\", \"type\", \"name\") VALUES (?, ?, ?)" }
-    it_behaves_like 'database error rescuing'
+    before do
+      allow(Rescuable).to(receive(:connection).and_return(double(
+        indexes: [],
+        primary_keys: ["namespace", "key"]
+      )))
+    end
+
+    context 'mysql' do
+      let(:message) { "Mysql2::Error: Duplicate entry 'existing_namespace-existing_key' for key 'PRIMARY'" }
+      it_behaves_like 'database error rescuing'
+    end
+
+    context 'psql' do
+      let(:message) { "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"postgresql_cpk_models_pkey\"\nDETAIL:  Key (namespace, key)=(existing_namespace, existing_key) already exists.\n" }
+      it_behaves_like 'database error rescuing'
+    end
+
+    context 'sqlite3' do
+      let(:message) { "SQLite3::ConstraintException: UNIQUE constraint failed: sqlite3_cpk_models.namespace, sqlite3_cpk_models.key" }
+      it_behaves_like 'database error rescuing'
+    end
   end
 end

--- a/spec/rescuer_spec.rb
+++ b/spec/rescuer_spec.rb
@@ -20,25 +20,49 @@ shared_examples 'a model with rescued unique error without validator' do
   describe 'create!' do
     context 'when catching a race condition' do
       before {
-        described_class.create!(relation_id: 1, handle: 'toto')
+        described_class.create!(params)
       }
 
       it 'adds an error on the model' do
-        model = described_class.create(relation_id: 1, handle: 'toto')
-        expect(model.errors[:handle]).to eq(["handle must be unique for this relation"])
+        model = described_class.create(params)
+        expect(model.errors[field]).to eq([error_message])
       end
     end
   end
 end
 
-describe Sqlite3Model do
-  it_behaves_like 'a model with rescued unique error without validator'
+context "unique key" do
+  let(:params) { { relation_id: 1, handle: 'toto' } }
+  let(:field) { :handle }
+  let(:error_message) { "handle must be unique for this relation" }
+
+  describe Sqlite3Model do
+    it_behaves_like 'a model with rescued unique error without validator'
+  end
+
+  describe MysqlModel do
+    it_behaves_like 'a model with rescued unique error without validator'
+  end
+
+  describe PostgresqlModel do
+    it_behaves_like 'a model with rescued unique error without validator'
+  end
 end
 
-describe MysqlModel do
-  it_behaves_like 'a model with rescued unique error without validator'
-end
+context "composite primary key" do
+  let(:params) { { namespace: 'test_namespace', key: 'test_key' } }
+  let(:field) { :key }
+  let(:error_message) { "must be unique within this namespace" }
 
-describe PostgresqlModel do
-  it_behaves_like 'a model with rescued unique error without validator'
+  describe Sqlite3CpkNoValidatorModel do
+    it_behaves_like 'a model with rescued unique error without validator'
+  end
+
+  describe MysqlCpkNoValidatorModel do
+    it_behaves_like 'a model with rescued unique error without validator'
+  end
+
+  describe PsqlCpkNoValidatorModel do
+    it_behaves_like 'a model with rescued unique error without validator'
+  end
 end


### PR DESCRIPTION
The function that was being used to find indexes [explicitly ignores primary keys](https://github.com/rails/rails/blob/12613accfdd5665600958c2c291f8377bc1f11e3/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb#L14). The change in this PR will manually append the primary key to the list.

This will let us handle duplicate errors for composite primary keys in MySQL.