### PR TITLE
Do not parse error message if there is no handlers to handle it

### DIFF
--- a/lib/rescue_from_duplicate/active_record/extension.rb
+++ b/lib/rescue_from_duplicate/active_record/extension.rb
@@ -43,11 +43,14 @@ module RescueFromDuplicate::ActiveRecord
     end
 
     def exception_handler(exception)
+      handlers = self.class._rescue_from_duplicate_handlers
+      return if handlers.empty?
+
       columns = exception_columns(exception)
       return unless columns
       columns = columns.sort
 
-      self.class._rescue_from_duplicate_handlers.detect do |handler|
+      handlers.detect do |handler|
         handler.rescue? && columns == handler.columns
       end
     end
@@ -67,7 +70,7 @@ module RescueFromDuplicate::ActiveRecord
     end
 
     def sqlite3_exception_columns(exception)
-      extract_columns(exception.message[/columns? (.*) (?:is|are) not unique/, 1]) || 
+      extract_columns(exception.message[/columns? (.*) (?:is|are) not unique/, 1]) ||
       extract_columns(exception.message[/UNIQUE constraint failed: ([^:]*)\:?/, 1])
     end
 

--- a/spec/rescue_from_duplicate_spec.rb
+++ b/spec/rescue_from_duplicate_spec.rb
@@ -26,6 +26,13 @@ shared_examples 'database error rescuing' do
       it "raises an exception" do
         expect { subject.create_or_update }.to raise_error(ActiveRecord::RecordNotUnique)
       end
+
+      it "doesn't parse the message" do
+        allow(uniqueness_exception).to(
+          receive(:message).and_raise(StandardError, "Message should not have been accessed")
+        )
+        expect { subject.create_or_update }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
     end
   end
 


### PR DESCRIPTION
Parsing message to get the column names is expensive, especially for MySQL as it requires reading schema cache or even going to the database to get index data.
Returning early if there are no handlers to handle exception allows us to avoid performing expensive message parsing.


