### PR TITLE
Use `schema_cache` if available

### DIFF
--- a/lib/rescue_from_duplicate/active_record.rb
+++ b/lib/rescue_from_duplicate/active_record.rb
@@ -16,7 +16,7 @@ module RescueFromDuplicate
     klasses.each do |klass|
       klass._rescue_from_duplicate_handlers.each do |handler|
         next unless klass.connection.table_exists?(klass.table_name)
-        unique_indexes = klass.connection.indexes(klass.table_name).select(&:unique)
+        unique_indexes = klass.connection.schema_cache.indexes(klass.table_name).select(&:unique)
 
         unless unique_indexes.any? { |index| index.columns.map(&:to_s).sort == handler.columns }
           missing_unique_indexes << MissingUniqueIndex.new(klass, handler.attributes, handler.columns)

--- a/lib/rescue_from_duplicate/active_record/extension.rb
+++ b/lib/rescue_from_duplicate/active_record/extension.rb
@@ -80,7 +80,7 @@ module RescueFromDuplicate::ActiveRecord
     end
 
     def other_exception_columns(exception)
-      indexes = self.class.connection.indexes(self.class.table_name)
+      indexes = self.class.connection.schema_cache.indexes(self.class.table_name)
       indexes.detect{ |i| exception.message.include?(i.name) }.try(:columns) || []
     end
   end

--- a/spec/rescue_from_duplicate_spec.rb
+++ b/spec/rescue_from_duplicate_spec.rb
@@ -7,7 +7,8 @@ shared_examples 'database error rescuing' do
   subject { Rescuable.new }
 
   before do
-    allow(Rescuable).to(receive(:connection).and_return(double(indexes: [Rescuable.index])))
+    connection = double(schema_cache: double(indexes: [Rescuable.index]))
+    allow(Rescuable).to(receive(:connection).and_return(connection))
   end
 
   describe "#create_or_update when the validation fails" do


### PR DESCRIPTION
Calling `connection.indexes` is expensive as it's a database call. If application has `schema_cache` enabled, we can use it to load indexes without going to the database.



### What reviewers should focus on

This gem formally supports very old versions of Rails and I'm thinking of releasing this change as a minor or even major version. We should also consider explicitly dropping support for Rails < 6 or even stricter 