### PR TITLE
Bump minimum required Active Record version to 7

### DIFF
--- a/activerecord-rescue_from_duplicate.gemspec
+++ b/activerecord-rescue_from_duplicate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.2"
+  spec.add_dependency "activerecord", ">= 7"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
In the next version of this gem we are dropping support for Active Record version earlier than `7`