### PR TITLE
Add MySQL healthcheck to CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           MYSQL_DATABASE: "rescue_from_duplicate"
         ports:
           - "3306:3306"
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
MySQL was often not ready to run tests on CI and this commit adds a healthcheck to ensure mysql is ready before proceeding to the tests

<img width="1271" alt="image" src="https://github.com/Shopify/activerecord-rescue_from_duplicate/assets/5512772/82b51a4e-fdfc-4acf-970b-0611f36c27ed">
