### PR TITLE
Add `add_error_to` option

### DIFF
--- a/lib/rescue_from_duplicate/active_record/extension.rb
+++ b/lib/rescue_from_duplicate/active_record/extension.rb
@@ -35,8 +35,8 @@ module RescueFromDuplicate::ActiveRecord
       handler = exception_handler(exception)
       return false unless handler
 
-      attribute = handler.attributes.first
-      options = handler.options.except(:case_sensitive, :scope).merge(value: self.send(:read_attribute_for_validation, attribute))
+      attribute = handler.error_attribute
+      options = handler.options.except(:case_sensitive, :scope).merge(value: read_attribute_for_validation(attribute))
 
       self.errors.add(attribute, :taken, **options)
       true

--- a/lib/rescue_from_duplicate/rescuer.rb
+++ b/lib/rescue_from_duplicate/rescuer.rb
@@ -1,8 +1,9 @@
 module RescueFromDuplicate
   class Rescuer
-    attr_reader :attributes, :options, :columns
+    attr_reader :attributes, :options, :columns, :error_attribute
 
     def initialize(attribute, options)
+      @error_attribute = options.delete(:add_error_to) || attribute
       @attributes = [attribute]
       @columns = [attribute, *Array(options[:scope])].map(&:to_s).sort
       @options = options

--- a/lib/rescue_from_duplicate/uniqueness_rescuer.rb
+++ b/lib/rescue_from_duplicate/uniqueness_rescuer.rb
@@ -16,6 +16,10 @@ module RescueFromDuplicate
       @validator.attributes
     end
 
+    def error_attribute
+      attributes.first
+    end
+
     def columns
       (Array(options[:scope]) + attributes).map(&:to_s).sort
     end

--- a/spec/rescue_from_duplicate_spec.rb
+++ b/spec/rescue_from_duplicate_spec.rb
@@ -49,21 +49,52 @@ shared_examples 'database error rescuing' do
       expect(subject.errors[:name]).to eq ["is not unique by type and shop id"]
     end
   end
+
+  describe "#create_or_update when using rescuer with add_error_to" do
+    let(:add_error_to_exception) { ::ActiveRecord::RecordNotUnique.new(name_normalized_message) }
+
+    before {
+      connection = double(schema_cache: double(indexes: [Rescuable.index_on_name_normalized]))
+      allow(Rescuable).to(receive(:connection).and_return(connection))
+      allow(Rescuable).to(receive(:_validators).and_return({}))
+      allow(Rescuable).to(receive(:_rescue_from_duplicates).and_return([Rescuable.uniqueness_rescuer_with_add_error_to]))
+      allow(Base).to(receive(:exception).and_return(add_error_to_exception))
+      subject.name = "My Title"
+    }
+
+    it "adds the error to the alternate attribute" do
+      subject.create_or_update
+      expect(subject.errors[:name]).to eq ["is not unique"]
+    end
+
+    it "reads the value from the alternate attribute" do
+      subject.create_or_update
+      expect(subject.errors.where(:name, :taken).first.options[:value]).to eq("My Title")
+    end
+
+    it "does not add an error to the index-matching attribute" do
+      subject.create_or_update
+      expect(subject.errors[:name_normalized]).to be_empty
+    end
+  end
 end
 
 describe RescueFromDuplicate::ActiveRecord do
   context 'mysql' do
     let(:message) { "Duplicate entry '1-Rescuable-toto' for key 'index_rescuable_on_shop_id_and_type_and_name'" }
+    let(:name_normalized_message) { "Duplicate entry '1-Rescuable-toto' for key 'index_rescuable_on_shop_id_and_type_and_name_normalized'" }
     it_behaves_like 'database error rescuing'
   end
 
   context 'pgsql' do
     let(:message) { "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"index_rescuable_on_shop_id_and_type_and_name\"\nDETAIL:  Key (shop_id, type, name)=(1, Rescuable, toto) already exists.\n: INSERT INTO \"postgresql_models\" (\"shop_id\", \"type\", \"name\") VALUES ($1, $2, $3) RETURNING \"id\"" }
+    let(:name_normalized_message) { "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"index_rescuable_on_shop_id_and_type_and_name_normalized\"\nDETAIL:  Key (shop_id, type, name_normalized)=(1, Rescuable, toto) already exists.\n: INSERT INTO \"postgresql_models\" (\"shop_id\", \"type\", \"name_normalized\") VALUES ($1, $2, $3) RETURNING \"id\"" }
     it_behaves_like 'database error rescuing'
   end
 
   context 'sqlite3' do
     let(:message) { "SQLite3::ConstraintException: column shop_id, type, name is not unique: INSERT INTO \"sqlite3_models\" (\"shop_id\", \"type\", \"name\") VALUES (?, ?, ?)" }
+    let(:name_normalized_message) { "SQLite3::ConstraintException: column shop_id, type, name_normalized is not unique: INSERT INTO \"sqlite3_models\" (\"shop_id\", \"type\", \"name_normalized\") VALUES (?, ?, ?)" }
     it_behaves_like 'database error rescuing'
   end
 end

--- a/spec/rescuer_spec.rb
+++ b/spec/rescuer_spec.rb
@@ -14,6 +14,23 @@ describe RescueFromDuplicate::Rescuer do
   it "returns the options" do
     expect(subject.options).to eq scope: [:type, :shop_id], message: "Derp!"
   end
+
+  describe "#error_attribute" do
+    it "defaults to the declared attribute" do
+      rescuer = RescueFromDuplicate::Rescuer.new(:name_normalized, scope: [:shop_id])
+      expect(rescuer.error_attribute).to eq(:name_normalized)
+    end
+
+    it "returns the add_error_to attribute when provided" do
+      rescuer = RescueFromDuplicate::Rescuer.new(:name_normalized, scope: [:shop_id], add_error_to: :name)
+      expect(rescuer.error_attribute).to eq(:name)
+    end
+
+    it "strips add_error_to from options" do
+      rescuer = RescueFromDuplicate::Rescuer.new(:name_normalized, scope: [:shop_id], add_error_to: :name, message: "taken")
+      expect(rescuer.options).to eq(scope: [:shop_id], message: "taken")
+    end
+  end
 end
 
 shared_examples 'a model with rescued unique error without validator' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,8 +30,8 @@ module RescueFromDuplicate
     include ActiveModel::AttributeMethods
     include RescueFromDuplicate::ActiveRecord::Extension
 
-    define_attribute_methods ['name']
-    attr_accessor :name
+    define_attribute_methods ['name', 'name_normalized', 'size']
+    attr_accessor :name, :name_normalized, :size
 
     def self.table_name
       "rescuable"
@@ -73,6 +73,12 @@ module RescueFromDuplicate
       )
     end
 
+    def self.uniqueness_rescuer_with_add_error_to
+      @uniqueness_rescuer_with_add_error_to ||= RescueFromDuplicate::Rescuer.new(
+        :name_normalized, scope: [:shop_id, :type], add_error_to: :name, message: "is not unique"
+      )
+    end
+
     def self.presence_validator
       @presence_validator ||= ActiveModel::Validations::PresenceValidator.new(attributes: [:name])
     end
@@ -83,6 +89,15 @@ module RescueFromDuplicate
         "index_rescuable_on_shop_id_and_type_and_name",
         true,
         ["shop_id", "type", "name"],
+      )
+    end
+
+    def self.index_on_name_normalized
+      @index_on_name_normalized ||= ::ActiveRecord::ConnectionAdapters::IndexDefinition.new(
+        "rescuable",
+        "index_rescuable_on_shop_id_and_type_and_name_normalized",
+        true,
+        ["shop_id", "type", "name_normalized"],
       )
     end
   end


### PR DESCRIPTION
In cases where case/accent insensitive collations are not available, it
is useful to add a `<attr>_normalized` proxy column to drive unique
indexes.

In these cases, should the uniqueness constraint be violated, we want to
show the user errors referencing their actual input, without the
`_normalized` field name, nor the normalized value.

## Usage

```ruby
class MyModel < ApplicationRecord
  rescue_from_duplicate :name_normalized, add_error_to: :name
end

elmo = MyModel.create!(name: "Elmo")
elmo.name
#=> "Elmo"
elmo.name_normalized
#=> "elmo"

eelmo = MyModel.build(name: "Élmo")
eelmo.valid?
#=> false
eelmo.errors[:name]
#=> "is not unique"
```
